### PR TITLE
added note for guzzle 6 compatibility

### DIFF
--- a/knpu/episode1/test-code-reuse.md
+++ b/knpu/episode1/test-code-reuse.md
@@ -21,6 +21,7 @@ And give `Client` a proper `use` statement:
 
 [[[ code('9263e01200') ]]]
 
+In case you are using Guzzle 6, you would need to pass the base to `base_uri` instead of `base_url`.
 Cool. So now the `Client` is created once per test suite. Now, create a
 `protected $client` property that is *not* static with some nice PHPDoc above
 it. Woops - make sure you actually make this `protected`: this is what we'll

--- a/knpu/episode1/test-code-reuse.md
+++ b/knpu/episode1/test-code-reuse.md
@@ -21,7 +21,9 @@ And give `Client` a proper `use` statement:
 
 [[[ code('9263e01200') ]]]
 
-In case you are using Guzzle 6, you would need to pass the base to `base_uri` instead of `base_url`.
+***TIP
+In case you are using Guzzle 6, you would need to use the `base_uri` key instead of `base_url` to configure Guzzle client properly.
+***
 Cool. So now the `Client` is created once per test suite. Now, create a
 `protected $client` property that is *not* static with some nice PHPDoc above
 it. Woops - make sure you actually make this `protected`: this is what we'll


### PR DESCRIPTION
guzzle 6, the latest version changed the base key from `base_url` to `base_uri`.
http://docs.guzzlephp.org/en/latest/quickstart.html?highlight=base_uri
