### PR TITLE
Adding notes on what needs to change for v2 of the lexik JWT bundle

### DIFF
--- a/knpu/episode4/jwt-guard-authenticator.md
+++ b/knpu/episode4/jwt-guard-authenticator.md
@@ -3,7 +3,7 @@
 To create our token authentication system, we'll use Guard.
 
 Guard is part of Symfony's core security system and makes setting up custom auth
-so easy it's actually fun. 
+so easy it's actually fun.
 
 ## Creating the Authenticator
 
@@ -17,6 +17,12 @@ quickly, go to the "Code"->"Generate" menu - `command`+`N` on a Mac - and select
 "Implement Methods". Select the ones under Guard:
 
 [[[ code('5b3b199654') ]]]
+
+***TIP
+Version 2 of LexikJWTAuthenticationBundle comes with an authenticator that's
+based off of the one we're about to build. Feel free to use it instead of
+building your own... once you learn how it works.
+***
 
 Now, do that *one* more time and also select the `start()` method. That'll put `start()`
 on the bottom, which will be more natural:
@@ -104,6 +110,30 @@ So, `if ($data === false)`, then we know that there's a problem with the token. 
 there is, throw a `new CustomUserMessageAuthenticationException()` with `Invalid token`:
 
 [[[ code('d3952ece00') ]]]
+
+***TIP
+In version 2 of the bundle, you should instead use a try-catch around this line:
+
+```php
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
+// ...
+
+public function getUser($credentials, UserProviderInterface $userProvider)
+{
+    try {
+        $data = $this->jwtEncoder->decode($credentials);
+    } catch (JWTDecodeFailureException $e) {
+        // if you want to, use can use $e->getReason() to find out which of the 3 possible things went wrong
+        // and tweak the message accordingly
+        // https://github.com/lexik/LexikJWTAuthenticationBundle/blob/05e15967f4dab94c8a75b275692d928a2fbf6d18/Exception/JWTDecodeFailureException.php
+
+        throw new CustomUserMessageAuthenticationException('Invalid Token');
+    }
+
+    // ...
+}
+```
+***
 
 We'll talk about what that does in a second.
 

--- a/knpu/episode4/lexikjwt-authentication-bundle.md
+++ b/knpu/episode4/lexikjwt-authentication-bundle.md
@@ -9,6 +9,11 @@ documentation. And now, you guys know the drill. Copy the library name from the
 composer require lexik/jwt-authentication-bundle
 ```
 
+***TIP
+Version 2 of this bundle is now out! Not much has changed, but we'll tell you
+when something is different!
+***
+
 While we're waiting for Jordi, I mean Composer to download that for us, let's keep
 busy. Copy the new bundle line and put that into `AppKernel`:
 


### PR DESCRIPTION
We'll also need to add some video notes!

## Video Notes:

A) http://knpuniversity.com/screencast/symfony-rest4/lexikjwt-authentication-bundle
Time: 0:24
Note:
> This command will now give you a new version (2) of this bundle is now out! Not much has
> changed, but we'll tell you when something is different!

B) http://knpuniversity.com/screencast/symfony-rest4/jwt-guard-authenticator
Time: 0:25
Note:
> Version 2 of LexikJWTAuthenticationBundle comes with an authenticator
> that's based off of the one we're about to build. Feel free to use it instead
> of building your own... once you learn how it works.

C) http://knpuniversity.com/screencast/symfony-rest4/jwt-guard-authenticator
Time: 4:17
Note:
> In Version 2 of LexikJWTAuthenticationBundle, you'll need to wrap this line in
> a try-catch block for `JWTDecodeFailureException` . See the tip on this page
> for the full code.