### PR TITLE
Public key is used to verify signatures

### DIFF
--- a/knpu/episode4/jwt-guard-authenticator.md
+++ b/knpu/episode4/jwt-guard-authenticator.md
@@ -97,9 +97,16 @@ string:
 That's it! `$data` is now an array of whatever information we originally put into
 the token. Fundamentally, this works just like a normal `json_decode`, except that
 the library is also checking to make sure that the contents of our token weren't
-changed. It does this by using our *private* key. This guarantees that nobody has
-changed the username to some *other* username because they're a jerk. Encryption
-is amazing.
+changed. It does this by using our *private* key.
+
+***TIP
+The private key is only used in case of symmetric signing. In the much more common
+case of assymetric signing the *private* key is used to sign the token, and the
+*public* key is used to verify the signature.
+***
+
+This guarantees that nobody has changed the username to some *other* username
+because they're a jerk. Encryption is amazing.
 
 It also checks the token's expiration: our tokens last 1 hour because that's what we
 setup in `config.yml`:

--- a/knpu/episode4/jwt-guard-authenticator.md
+++ b/knpu/episode4/jwt-guard-authenticator.md
@@ -100,8 +100,8 @@ the library is also checking to make sure that the contents of our token weren't
 changed. It does this by using our *private* key.
 
 ***TIP
-The private key is only used in case of symmetric signing. In the much more common
-case of assymetric signing the *private* key is used to sign the token, and the
+The private key is only used in the case of symmetric signing. In the much more common
+case of asymmetric signing, the *private* key is used to sign the token, and the
 *public* key is used to verify the signature.
 ***
 


### PR DESCRIPTION
It's actually the public key which is used for verification of the signature, unless there is a symmetrical algorithm used (as there is only the private key then). I also changed the other sentence, hope I don't sound like I'm picking on you - the signature and encryption are two different things when it comes to JWTs. Most of them are signed, but encryption is not that widely used. So something like "Cryptography is amazing" is a better phrase here. It was bothering me when I saw that, but feel free to ignore this if you feel it's too minor. :)